### PR TITLE
Add dashboard viewer role and view-only dashboard page

### DIFF
--- a/client/app/pages/dashboards/DashboardViewerPage.jsx
+++ b/client/app/pages/dashboards/DashboardViewerPage.jsx
@@ -1,0 +1,101 @@
+import { isEmpty } from "lodash";
+import React from "react";
+import PropTypes from "prop-types";
+
+import routeWithUserSession from "@/components/ApplicationArea/routeWithUserSession";
+import BigMessage from "@/components/BigMessage";
+import PageHeader from "@/components/PageHeader";
+import Parameters from "@/components/Parameters";
+import DashboardGrid from "@/components/dashboards/DashboardGrid";
+import Filters from "@/components/Filters";
+
+import { Dashboard } from "@/services/dashboard";
+import routes from "@/services/routes";
+
+import useDashboard from "./hooks/useDashboard";
+
+import "./PublicDashboardPage.less";
+
+function ViewerDashboard({ dashboard }) {
+  const { globalParameters, filters, setFilters, refreshDashboard, loadWidget, refreshWidget } = useDashboard(
+    dashboard
+  );
+
+  return (
+    <div className="container p-t-10 p-b-20">
+      <PageHeader title={dashboard.name} />
+      {!isEmpty(globalParameters) && (
+        <div className="m-b-10 p-15 bg-white tiled">
+          <Parameters parameters={globalParameters} onValuesChange={refreshDashboard} />
+        </div>
+      )}
+      {!isEmpty(filters) && (
+        <div className="m-b-10 p-15 bg-white tiled">
+          <Filters filters={filters} onChange={setFilters} />
+        </div>
+      )}
+      <div id="dashboard-container">
+        <DashboardGrid
+          dashboard={dashboard}
+          widgets={dashboard.widgets}
+          filters={filters}
+          isEditing={false}
+          isPublic
+          onLoadWidget={loadWidget}
+          onRefreshWidget={refreshWidget}
+        />
+      </div>
+    </div>
+  );
+}
+
+ViewerDashboard.propTypes = {
+  dashboard: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+};
+
+class DashboardViewerPage extends React.Component {
+  static propTypes = {
+    dashboardId: PropTypes.string.isRequired,
+    onError: PropTypes.func,
+  };
+
+  static defaultProps = {
+    onError: () => {},
+  };
+
+  state = {
+    loading: true,
+    dashboard: null,
+  };
+
+  componentDidMount() {
+    Dashboard.getViewer({ id: this.props.dashboardId })
+      .then(dashboard => this.setState({ dashboard, loading: false }))
+      .catch(error => this.props.onError(error));
+  }
+
+  render() {
+    const { loading, dashboard } = this.state;
+    return (
+      <div className="public-dashboard-page">
+        {loading ? (
+          <div className="container loading-message">
+            <BigMessage className="" icon="fa-spinner fa-2x fa-pulse" message="Loading..." />
+          </div>
+        ) : (
+          <ViewerDashboard dashboard={dashboard} />
+        )}
+      </div>
+    );
+  }
+}
+
+routes.register(
+  "Dashboards.Viewer",
+  routeWithUserSession({
+    path: "/dashboards/viewer/:dashboardId",
+    render: pageProps => <DashboardViewerPage {...pageProps} dashboardId={pageProps.routeParams.dashboardId} />,
+  })
+);
+
+export default DashboardViewerPage;

--- a/client/app/pages/home/Home.jsx
+++ b/client/app/pages/home/Home.jsx
@@ -11,11 +11,12 @@ import PlainButton from "@/components/PlainButton";
 
 import { axios } from "@/services/axios";
 import recordEvent from "@/services/recordEvent";
-import { messages } from "@/services/auth";
+import { messages, currentUser } from "@/services/auth";
 import notification from "@/services/notification";
 import routes from "@/services/routes";
 
 import { DashboardAndQueryFavoritesList } from "./components/FavoritesList";
+import DashboardListHome from "./components/DashboardListHome";
 
 import "./Home.less";
 
@@ -89,7 +90,11 @@ export default function Home() {
           />
         </DynamicComponent>
         <DynamicComponent name="HomeExtra" />
-        <DashboardAndQueryFavoritesList />
+        {currentUser.hasPermission("list_dashboards") && !currentUser.hasPermission("view_query") ? (
+          <DashboardListHome />
+        ) : (
+          <DashboardAndQueryFavoritesList />
+        )}
         <BeaconConsent />
       </div>
     </div>

--- a/client/app/pages/home/components/DashboardListHome.jsx
+++ b/client/app/pages/home/components/DashboardListHome.jsx
@@ -1,0 +1,29 @@
+import React, { useState, useEffect } from "react";
+import Link from "@/components/Link";
+import { Dashboard } from "@/services/dashboard";
+
+export default function DashboardListHome() {
+  const [dashboards, setDashboards] = useState([]);
+
+  useEffect(() => {
+    Dashboard.query({ page_size: 20 }).then(({ results }) => setDashboards(results));
+  }, []);
+
+  return (
+    <div className="tile">
+      <div className="t-body tb-padding">
+        <div className="d-flex align-items-center m-b-20">
+          <p className="flex-fill f-500 c-black m-0">Dashboards</p>
+        </div>
+        <div role="list" className="list-group">
+          {dashboards.map(d => (
+            <Link key={d.id} role="listitem" className="list-group-item" href={`/dashboards/viewer/${d.id}`}> 
+              {d.name}
+              {d.is_draft && <span className="label label-default m-l-5">Unpublished</span>}
+            </Link>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/app/pages/index.js
+++ b/client/app/pages/index.js
@@ -10,6 +10,7 @@ import "./alert/Alert";
 import "./dashboards/DashboardList";
 import "./dashboards/DashboardPage";
 import "./dashboards/PublicDashboardPage";
+import "./dashboards/DashboardViewerPage";
 
 import "./data-sources/DataSourcesList";
 import "./data-sources/EditDataSource";

--- a/client/app/services/dashboard.js
+++ b/client/app/services/dashboard.js
@@ -164,6 +164,7 @@ const DashboardService = {
     return axios.get(`api/dashboards/${id || slug}`, { params }).then(transformResponse);
   },
   getByToken: ({ token }) => axios.get(`api/dashboards/public/${token}`).then(transformResponse),
+  getViewer: ({ id }) => axios.get(`api/dashboards/${id}/viewer`).then(transformResponse),
   save: data => axios.post(saveOrCreateUrl(data), data).then(transformResponse),
   delete: ({ id }) => axios.delete(`api/dashboards/${id}`).then(transformResponse),
   query: params => axios.get("api/dashboards", { params }).then(transformResponse),

--- a/redash/handlers/api.py
+++ b/redash/handlers/api.py
@@ -18,6 +18,7 @@ from redash.handlers.dashboards import (
     DashboardResource,
     DashboardShareResource,
     DashboardTagsResource,
+    DashboardViewerResource,
     MyDashboardsResource,
     PublicDashboardResource,
 )
@@ -137,6 +138,11 @@ api.add_org_resource(
     PublicDashboardResource,
     "/api/dashboards/public/<token>",
     endpoint="public_dashboard",
+)
+api.add_org_resource(
+    DashboardViewerResource,
+    "/api/dashboards/<dashboard_id>/viewer",
+    endpoint="dashboard_viewer",
 )
 api.add_org_resource(
     DashboardShareResource,

--- a/redash/handlers/dashboards.py
+++ b/redash/handlers/dashboards.py
@@ -292,6 +292,13 @@ class PublicDashboardResource(BaseResource):
         return public_dashboard(dashboard)
 
 
+class DashboardViewerResource(BaseResource):
+    @require_permission("list_dashboards")
+    def get(self, dashboard_id):
+        dashboard = get_object_or_404(models.Dashboard.get_by_id_and_org, dashboard_id, self.current_org)
+        return public_dashboard(dashboard)
+
+
 class DashboardShareResource(BaseResource):
     def post(self, dashboard_id):
         """

--- a/redash/models/__init__.py
+++ b/redash/models/__init__.py
@@ -1483,8 +1483,14 @@ def init_db():
         org=default_org,
         type=Group.BUILTIN_GROUP,
     )
+    dashboard_viewer_group = Group(
+        name="dashboard_viewer",
+        permissions=Group.DASHBOARD_VIEWER_PERMISSIONS,
+        org=default_org,
+        type=Group.BUILTIN_GROUP,
+    )
 
-    db.session.add_all([default_org, admin_group, default_group])
+    db.session.add_all([default_org, admin_group, default_group, dashboard_viewer_group])
     # XXX remove after fixing User.group_ids
     db.session.commit()
-    return default_org, admin_group, default_group
+    return default_org, admin_group, default_group, dashboard_viewer_group

--- a/redash/models/users.py
+++ b/redash/models/users.py
@@ -258,6 +258,7 @@ class Group(db.Model, BelongsToOrgMixin):
         "list_alerts",
         "list_data_sources",
     ]
+    DASHBOARD_VIEWER_PERMISSIONS = ["list_dashboards"]
     ADMIN_PERMISSIONS = ["admin", "super_admin"]
 
     BUILTIN_GROUP = "builtin"


### PR DESCRIPTION
## Summary
- add `dashboard_viewer` built-in group
- expose `/api/dashboards/<id>/viewer` endpoint for logged-in read-only dashboard views
- show dashboards list on home page when user lacks query permissions
- add front-end `DashboardViewerPage`
- cleanup `DashboardListHome` component

## Testing
- `make lint`
- `make tests` *(fails: docker not available)*